### PR TITLE
feat: implement useGameLoop hook to fix missing game loop (#34)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { useGameReducer } from './hooks/useGameReducer'
+import { useGameLoop } from './hooks/useGameLoop'
 import ScreenManager from './components/ScreenManager'
 
 export default function App() {
   const { state, dispatch } = useGameReducer()
+  useGameLoop(state, dispatch)
 
   return <ScreenManager state={state} dispatch={dispatch} />
 }

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react'
+import type { Dispatch } from 'react'
+import type { GameState } from '../types'
+import type { GameAction } from './useGameReducer'
+import { spawn } from '../services/wordSpawner'
+import { getBestScore, saveBestScore } from '../services/localStorageService'
+
+export function useGameLoop(state: GameState, dispatch: Dispatch<GameAction>) {
+  // Ref로 최신 lastWord 추적 (interval이 stale closure 참조하지 않도록)
+  const lastWordRef = useRef<string | null>(state.lastWord)
+  const prevScreenRef = useRef<GameState['screen']>(state.screen)
+
+  useEffect(() => {
+    lastWordRef.current = state.lastWord
+  }, [state.lastWord])
+
+  // ── 게임 루프: TICK / SPAWN_WORD / REMOVE_EXPIRED ────────────────────────
+  useEffect(() => {
+    if (state.screen !== 'playing') return
+
+    const tickInterval = setInterval(() => {
+      dispatch({ type: 'TICK' })
+    }, 1000)
+
+    const spawnInterval = setInterval(() => {
+      dispatch({ type: 'SPAWN_WORD', word: spawn(lastWordRef.current) })
+    }, 1500)
+
+    const expireInterval = setInterval(() => {
+      dispatch({ type: 'REMOVE_EXPIRED' })
+    }, 500)
+
+    return () => {
+      clearInterval(tickInterval)
+      clearInterval(spawnInterval)
+      clearInterval(expireInterval)
+    }
+  }, [state.screen, dispatch])
+
+  // ── 게임 종료 처리: 최고 점수 저장 + END_GAME dispatch ──────────────────
+  useEffect(() => {
+    if (prevScreenRef.current === 'playing' && state.screen === 'result') {
+      const prev = getBestScore()
+      const isNewBestScore = state.score > prev
+      saveBestScore(state.score)
+      dispatch({ type: 'END_GAME', isNewBestScore })
+    }
+    prevScreenRef.current = state.screen
+  }, [state.screen, state.score, dispatch])
+}


### PR DESCRIPTION
## Summary

- `src/hooks/useGameLoop.ts` 생성: playing 상태 동안 게임 루프 구동
- 1초마다 `TICK`, 1.5초마다 `SPAWN_WORD`, 500ms마다 `REMOVE_EXPIRED` dispatch
- result 전환 시 `saveBestScore` 호출 + `END_GAME` dispatch (`isNewBestScore` 포함)
- `App.tsx`에서 `useGameLoop(state, dispatch)` 호출로 활성화
- `screen !== 'playing'` 시 모든 interval이 useEffect cleanup으로 자동 정지

## AC Checklist

- [x] `src/hooks/useGameLoop.ts`가 존재한다
- [x] `screen === 'playing'` 동안 단어가 1.5초 간격으로 화면에 나타난다
- [x] 타이머가 1초마다 감소하며 0이 되면 result 화면으로 전환된다
- [x] 수명이 만료된 단어는 자동으로 제거된다
- [x] 게임 종료 시 최고 점수가 localStorage에 저장되고 `isNewBestScore`가 올바르게 설정된다
- [x] `screen !== 'playing'`이면 모든 인터벌이 정지된다

## Test plan

- [x] `npm run build` 빌드 성공
- [x] `npm test` 21개 유닛 테스트 전체 통과

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)